### PR TITLE
エディターのアイコンを設定

### DIFF
--- a/public/editor/index.html
+++ b/public/editor/index.html
@@ -68,7 +68,12 @@
                 id="btn-line"
               >
               <label class="tool-button" for="btn-line">
-                &#x36;
+                <!-- 線分のアイコン -->
+                <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="8" y1="22" x2="22" y2="8" stroke-width="2" stroke="currentColor"/>
+                  <circle cx="8" cy="22" r="3", fill="currentColor"/>
+                  <circle cx="22" cy="8" r="3", fill="currentColor"/>
+                </svg>
               </label>
 
               <input
@@ -77,7 +82,25 @@
                 id="btn-erase"
               >
               <label class="tool-button" for="btn-erase">
-                &#x38;
+                <!-- 消しゴムのアイコン -->
+                <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-width="1.5" stroke="currentColor" fill="#ccf" d="
+                    M15,25
+                    H5
+                    V18
+                    L15,5
+                    H25
+                    V12
+                    Z
+                  "/>
+                  <path stroke-width="1.5" stroke="currentColor" fill="none" d="
+                    M5,18
+                    H15
+                    V25
+                    M15,18
+                    L25,5
+                  "/>
+                </svg>
               </label>
 
               <input


### PR DESCRIPTION
## 概要

直線モードのアイコンを直線っぽいのに, 消しゴムモードのアイコンを消しゴムっぽいのにしました.

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

<!-- このPRに関するテストケースなどを記述してください -->

## レビュアーチェックリスト

- `/editor/`を見てそれっぽいか確認して下さい.