### PR TITLE
エディタータイトル入力のアウトラインを消す

### DIFF
--- a/public/editor/index.css
+++ b/public/editor/index.css
@@ -70,6 +70,7 @@ body {
 
 #title-input {
   margin-bottom: 5px;
+  outline: none;
 }
 
 .menu-bar {


### PR DESCRIPTION
## 概要

- タイトルの通り, アウトライン(入力するとき周りが青くなるあれ)を消します.

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

- `/editor/`でタイトルを編集してみて, チェックしてください.

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
