### PR TITLE
AAから画像に変換する処理

### DIFF
--- a/public/editor/tools/util.js
+++ b/public/editor/tools/util.js
@@ -118,4 +118,26 @@ export class CharPlace {
       return r;
     }).join("\n").trimEnd();
   }
+
+  /**
+   * @returns {[number, number, number, number]} [上端, 右端, 下端, 左端]
+   */
+  getRect() {
+    const r = [this.#chars.length, 0, 0, this.#width];
+    let flg = true;
+    for (let i = 0; i < this.#chars.length; ++i) {
+      const line = this.#chars[i];
+      for (const { offset, char } of line) {
+        flg = false;
+        const roffset = offset + charwidth[char];
+        if (i < r[0]) r[0] = i;
+        if (roffset > r[1]) r[1] = roffset;
+        if (i + 1 > r[2]) r[2] = i + 1;
+        if (offset < r[3]) r[3] = offset;
+      }
+    }
+    // 文字が無い場合, バグらないように適当な領域を割り当てる
+    if (flg) return [0, 18, 1, 0];
+    return r;
+  }
 }

--- a/public/util/aa2img-test.html
+++ b/public/util/aa2img-test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AA画像変換テスト</title>
+  </head>
+  <body>
+    <script type="module">
+      import { aa2blob } from "./aa2img.js";
+      const img = document.createElement("img");
+      img.src = await aa2blob("国Ajy|g\n国Ajy|g");
+      document.body.append(img);
+    </script>
+  </body>
+</html>

--- a/public/util/aa2img.js
+++ b/public/util/aa2img.js
@@ -1,0 +1,22 @@
+import { CharPlace } from "../editor/tools/util.js";
+
+/** @type {OffscreenCanvas} */
+const canvas = new OffscreenCanvas(1, 1);
+/** @type {OffscreenCanvasRenderingContext2D} */
+const ctx = canvas.getContext("2d");
+
+/**
+ * @param {string} aa
+ */
+export const aa2blob = async (aa) => {
+  const [top, right, bottom, left] = new CharPlace(aa, 1000, 720).getRect();
+  canvas.width = right - left;
+  canvas.height = (bottom - top) * 18;
+  ctx.font = "12pt 'MS PGothic'";
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const saa = aa.split("\n");
+  for (let i = 0; i < saa.length; ++i) {
+    ctx.fillText(saa[i], 0 - left, (i - top) * 18 + 15);
+  }
+  return URL.createObjectURL(await canvas.convertToBlob());
+};


### PR DESCRIPTION
## 概要

- `util/aa2img.js`にAAを入力するとその画像のURLを返す関数`aa2blob`を実装しました.

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

- `/util/aa2img-test.html`にテスト文字列を表示するページがあります.

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
