### PR TITLE
エディターのテキスト入力時の不正なAA入力防止

### DIFF
--- a/public/editor/index.js
+++ b/public/editor/index.js
@@ -145,6 +145,18 @@ document.addEventListener("DOMContentLoaded", () => {
       textarea.removeEventListener("change", onchange);
     };
   });
+  // 初期でテキスト入力モードにする
+  {
+    textModeButton.click();
+    overwrap.style.display = "none";
+    const onchange = () => {
+      textarea.value = new CharPlace(textarea.value, 1000, 40).toAA();
+    };
+    textarea.addEventListener("change", onchange);
+    finishmode = () => {
+      textarea.removeEventListener("change", onchange);
+    };
+  }
   lineModeButton.addEventListener("change", () => {
     finishmode();
     overwrap.style.display = "block";

--- a/public/editor/index.js
+++ b/public/editor/index.js
@@ -1,5 +1,6 @@
 import { line } from "./tools/line.js";
 import { erase } from "./tools/erase.js";
+import { CharPlace } from "./tools/util.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   const newButton = document.getElementById("btn-new");
@@ -136,6 +137,13 @@ document.addEventListener("DOMContentLoaded", () => {
   textModeButton.addEventListener("change", () => {
     finishmode();
     overwrap.style.display = "none";
+    const onchange = () => {
+      textarea.value = new CharPlace(textarea.value, 1000, 40).toAA();
+    };
+    textarea.addEventListener("change", onchange);
+    finishmode = () => {
+      textarea.removeEventListener("change", onchange);
+    };
   });
   lineModeButton.addEventListener("change", () => {
     finishmode();

--- a/public/editor/tools/util.js
+++ b/public/editor/tools/util.js
@@ -20,11 +20,13 @@ export class CharPlace {
     this.#chars = [];
     this.#width = width;
     for (const line of aa.split("\n")) {
+      if (this.#chars.length >= height) break;
       /** @type {{ offset: number, char: string }[]} */
       const lineChars = [];
       let offset = 0;
       for (const char of line) {
         if (!(char in charwidth)) continue;
+        if (offset + charwidth[char] > width) continue;
         if (!whiteSpace.includes(char)) {
           lineChars.push({ offset, char });
         }


### PR DESCRIPTION
## 概要

- 幅が広すぎる, 高さが高すぎるAAをテキスト入力時に入れたら入力終了時点で切り詰めるようにしました.

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

- `/editor/`であああああ...みたいに入力して挙動を確認してください.

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
