### PR TITLE
ユーザー名とAAのバリデーション

### DIFF
--- a/public/editor/tools/util.js
+++ b/public/editor/tools/util.js
@@ -143,3 +143,10 @@ export class CharPlace {
     return r;
   }
 }
+
+/**
+ * AAを正規化する
+ * @param {string} aa
+ * @returns {string}
+ */
+export const normalize = (aa) => new CharPlace(aa, 1000, 40).toAA();

--- a/public/login/signup.js
+++ b/public/login/signup.js
@@ -3,6 +3,16 @@ document.querySelector("#signupForm").addEventListener("submit", async (e) => {
   try {
     const username = document.querySelector("#username").value;
     const password = document.querySelector("#password").value;
+    if (!/^[0-9A-Za-z_-]{2,20}$/.test(username)) {
+      if (!/^[0-9A-Za-z_-]*$/.test(username)) {
+        alert(
+          "ユーザー名に使える文字は\n- 半角英数字\n- ハイフン(-)\n- アンダーバー(_)\nだけです",
+        );
+      } else if (username.length < 2 || 20 < username.length) {
+        alert("ユーザー名は2文字以上20文字以内である必要があります");
+      }
+      return;
+    }
     const response = await fetch("/signup", {
       method: "POST",
       body: JSON.stringify({ username, password }),

--- a/server.deno.js
+++ b/server.deno.js
@@ -80,6 +80,9 @@ Deno.serve(async (req) => {
   if (req.method === "POST" && pathname === "/signup") {
     try {
       const { username, password } = await req.json();
+      if (!/^[0-9A-Za-z_-]{2,20}$/.test(username)) {
+        return new Response("そのユーザー名は登録できません", { status: 400 });
+      }
 
       // ユーザー名の重複チェック
       const userEntry = await kv.get(["users", username]);

--- a/server.deno.js
+++ b/server.deno.js
@@ -1,6 +1,7 @@
 import { serveDir } from "jsr:@std/http/file-server";
 import { getCookies, setCookie } from "jsr:@std/http/cookie";
 import { battle } from "./battle.server.js";
+import { normalize } from "./public/editor/tools/util.js";
 
 // パスワードハッシュ化の関数
 async function hashPassword(password) {
@@ -193,7 +194,7 @@ Deno.serve(async (req) => {
         .set(["aa", aaId], {
           author: username,
           title: title,
-          content: AA,
+          content: normalize(AA),
           created_at: now,
           updated_at: now,
         })
@@ -274,7 +275,7 @@ Deno.serve(async (req) => {
         .set(originalKey, {
           ...originalEntry.value,
           title: title,
-          content: AA,
+          content: normalize(AA),
           updated_at: newTimestamp,
         })
         .delete(["aa_by_user", username, +originalTimestamp])


### PR DESCRIPTION
## 概要

- 変なユーザー名やAAがデータベースに登録されないようにしました
- ユーザー名は「半角英数字, ハイフン, アンダーバーが2文字以上20文字以下」という制約が付きます.

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

- アカウントを作ろうとして試そう

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
